### PR TITLE
Extend pointer style to <a> tags without links

### DIFF
--- a/css/bootstrap-additions.css
+++ b/css/bootstrap-additions.css
@@ -6,6 +6,9 @@ option {
 	text-align: center;
 	text-align-last: center;
 }
+a {
+	cursor: pointer;
+}
 .btn-outline {
 	border-color: #ccc;
 	border-radius: 4px;


### PR DESCRIPTION
This wasn't targeting `<a id="extra-rules">`.