### PR TITLE
Short games shouldn't remove the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
       <div class="row">
           <div class="panel panel-info">
             <div class="panel-body">
-              <div class="card">
+              <div class="card footer">
       <p><em>A game by <a href="http://www.steven.li/" target="_blank">Steven Li</a>. Based off the game <a href="https://boardgamegeek.com/boardgame/2381/scattergories" target="_blank">Scattergories</a>. If you had fun, <a href="https://twitter.com/intent/tweet?text=www.steven.li%2Fnameit" target="_blank">tweet about it</a> or <a href="http://eepurl.com/cxkP6j" target="_blank">sign up for news</a>.</em></p>
               </div><!-- /.card -->
             </div><!-- /.panel-body -->

--- a/js/game.js
+++ b/js/game.js
@@ -60,6 +60,7 @@ function shortenGame() {
 	game_duration = shortGameDuration;
 	var categories = $(".card")
 		.not(".score-card")
+		.not(".footer")
 		.not(".new-game");
 	categories.slice((shortGameCategories + 1) * 2).remove();
 }


### PR DESCRIPTION
Currently we clear off all cards past a certain count. We already had exclusions for the score and new game button, but needed to add an exclusion for the footer.