### PR TITLE
Remove dead mailing list link and tweet intent

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
           <div class="panel panel-info">
             <div class="panel-body">
               <div class="card footer">
-      <p><em>A game by <a href="http://www.steven.li/" target="_blank">Steven Li</a>. Based off the game <a href="https://boardgamegeek.com/boardgame/2381/scattergories" target="_blank">Scattergories</a>. If you had fun, <a href="https://twitter.com/intent/tweet?text=www.steven.li%2Fnameit" target="_blank">tweet about it</a> or <a href="http://eepurl.com/cxkP6j" target="_blank">sign up for news</a>.</em></p>
+      <p><em>A game by <a href="http://www.steven.li/" target="_blank">Steven Li</a>. Based off the game <a href="https://boardgamegeek.com/boardgame/2381/scattergories" target="_blank">Scattergories</a>.</em></p>
               </div><!-- /.card -->
             </div><!-- /.panel-body -->
           </div><!-- /.panel panel-info -->


### PR DESCRIPTION
Not sure why my Mailchimp account disappeared, but better to take down the email and Twitter links altogether.